### PR TITLE
Support IE8. Reduce size of dependencies.

### DIFF
--- a/lib/urlencode.js
+++ b/lib/urlencode.js
@@ -14,7 +14,7 @@
  */
 
 var iconv = require('iconv-lite');
-var utility = require('utility');
+var _ = require('underscore');
 
 function isUTF8(charset) {
   if (!charset) {
@@ -131,7 +131,7 @@ function parse(qs, sep, eq, options) {
       v = vstr;
     }
 
-    if (!utility.hasOwnProperty(obj, k)) {
+    if (!_.has(obj, k)) {
       obj[k] = v;
     } else if (Array.isArray(obj[k])) {
       obj[k].push(v);

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "iconv-lite": "~0.4.11",
-    "utility": "~1.4.0"
+    "underscore": "~1.8.3",
   },
   "devDependencies": {
     "autod": "*",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "iconv-lite": "~0.4.11",
-    "underscore": "~1.8.3",
+    "underscore": "~1.8.3"
   },
   "devDependencies": {
     "autod": "*",


### PR DESCRIPTION
I'm working on a project to use this in a site that needs to support IE8. Several of the "utility" imports are causing problems. This provides the same functionality with a smaller footprint.